### PR TITLE
[wip] Bugfix focusable element edge cases and additional elements types

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,9 +13,20 @@ const BOUNDER_LINK_CLASS_NAME = "FocusBounder-link";
  * @see https://developer.mozilla.org/en-US/docs/Web/CSS/:not
  */
 const FOCUSABLE_ELEMENTS_SELECTORS = [
-  `a:not(.${BOUNDER_LINK_CLASS_NAME}):not([disabled])`,
-  "button:not([disabled]), input:not([disabled])",
-  "select:not([disabled]), textarea:not([disabled])",
+  // edge cases: links must have hrefs to be focusable
+  `a[href]:not(.${BOUNDER_LINK_CLASS_NAME})`,
+
+  // edge cases: all items with tabindex are focusable but must be >=0
+  "[tabindex]:not([tabindex=-1]),
+
+  // contenteditable
+  `[contenteditable]`,
+  
+  // form elements
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
 ];
 
 /**


### PR DESCRIPTION
Aims to resolve bugs and edge cases with what is and is not focusable inside the Focus Bounder. I'm not sure whether/how to children elements like `<a href="#" style="display:none">should not be focusable</a>` which would appear to be focusable from the HTML but actually aren't.

## Description

- [ ] should handle common edge cases such aas:
  - [ ] _not_ focus on disabled controls which should be focusable (ref. https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_disabled_controls)
  - [ ] be able to focus arbitrary elements with a tab index (partially complete in PR)
  - [x] be able to focus contenteditable nodes
  - [x] be able to focus links using `disabled` attribute
  - [x] _not be able to focus_ links which lack an href
- [ ] update tests cases
  - cover the noted edge cases
  - explicitly cover the edge cases covered in https://dequeuniversity.com/rules/axe/4.1/aria-hidden-focus
  - include axe-core dependency to make sure that we not provide inaccessible tests exampless
- [ ] update documentation
  - update `list` example in README to be a modal or other element which requires looping focus (refs https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal)
  - document additional edge cases and usage

## References
* disabled controls which can be focused - https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_disabled_controls
* https://github.com/dequelabs/axe-core/blob/master/lib/commons/dom/get-tabbable-elements.js
* compare with `axe-core`'s determination of [`isFocusable`](https://github.com/dequelabs/axe-core/blob/master/lib/commons/dom/is-focusable.js)  and [`isTabbable`](https://github.com/dequelabs/axe-core/blob/master/lib/commons/dom/get-tabbable-elements.js)

## Type of Change

- [x] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation (TODO)
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](https://github.com/wayfair-incubator/oss-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
